### PR TITLE
Fixed typo in symposium.html, logging to lodging

### DIFF
--- a/symposium.html
+++ b/symposium.html
@@ -156,7 +156,7 @@
     <h3>Description: <br/><br/><p>On Tuesday January 10th 2017, one day prior to the start of the ESIP Winter Meeting, the ESIP Semantic Technologies Committee will be hosting a one day GeoSemantics Symposium. The event will be held at Bethesda North Marriott (the same location as the ESIP meeting) with the intention to bring together the geoscience community interest in Semantic Web, and more broadly Semantic Technologies, to discuss potential collaborations, reuse, and road mapping. We’d like to fully leverage all of the semantic work happening in our respective communities, avoid duplication of effort, and work towards a broad community-endorsed path forward.
     </p>
 
-    <p>We seek broad community input and encourage non-ESIP members and members of other professional societies to attend. The event itself is free; however, attendees will be responsible for providing their own travel and logging. The exact room within the Marriott is still being worked out and will be provided in future announcements. Also, suggestions for topics to be covered are welcome.</p></h3>
+    <p>We seek broad community input and encourage non-ESIP members and members of other professional societies to attend. The event itself is free; however, attendees will be responsible for providing their own travel and lodging. The exact room within the Marriott is still being worked out and will be provided in future announcements. Also, suggestions for topics to be covered are welcome.</p></h3>
     <img style="display: block;margin: 0 auto;" src="http://www.esipfed.org/sites/default/files/esip-logo.png" width="72" height="48" alt="ESIPfed"/>
 
   </body>


### PR DESCRIPTION
Fixed a typo in the symposium description text.